### PR TITLE
v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Added
+- `Range::`{`$start_excluded`,`$end_excluded`} to obtain the range extremes excluding one or both of them.
+
 ## v2.6.0 2026-04-23
 ### Added
 - `Number::normalize()` to transform a variety of input types to a `Number` object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## v2.7.0 2026-05-13
 ### Added
 - `Range::`{`$start_excluded`,`$end_excluded`} to obtain the range extremes excluding one or both of them.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ![GitHub License](https://img.shields.io/github/license/MarcoConsiglio/bcmath-extended)
 ![GitHub Release](https://img.shields.io/github/v/release/MarcoConsiglio/bcmath-extended)
-![Static Badge](https://img.shields.io/badge/version-v2.5.0-white)
+![Static Badge](https://img.shields.io/badge/version-v2.7.0-white)
 <br>
 ![Static Badge](https://img.shields.io/badge/99%25-rgb(40%2C%20167%2C%2069)?label=Line%20coverage&labelColor=rgb(255%2C255%2C255))
 ![Static Badge](https://img.shields.io/badge/94%25-rgb(40%2C%20167%2C%2069)?label=Branch%20coverage&labelColor=rgb(255%2C255%2C255))
-![Static Badge](https://img.shields.io/badge/87%25-rgb(255%2C193%2C7)?label=Path%20coverage&labelColor=rgb(255%2C255%2C255))
+![Static Badge](https://img.shields.io/badge/86%25-rgb(255%2C193%2C7)?label=Path%20coverage&labelColor=rgb(255%2C255%2C255))
 
 
 

--- a/docs/html/classes/MarcoConsiglio-BCMathExtended-Range.html
+++ b/docs/html/classes/MarcoConsiglio-BCMathExtended-Range.html
@@ -119,7 +119,7 @@
         <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">9</span>
+    <span class="phpdocumentor-element-found-in__line">10</span>
 
     </aside>
 
@@ -159,11 +159,27 @@
 <dd>The higher extreme of this `Range`.</dd>
 
             <dt class="phpdocumentor-table-of-contents__entry -property -public">
+    <a class="" href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_end_excluded">$end_excluded</a>
+    <span>
+                        &nbsp;: <a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a>            </span>
+</dt>
+<dd>The higher extreme excluded, meaning the returning value is greater than
+`$end`.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -public">
     <a class="" href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_start">$start</a>
     <span>
                         &nbsp;: <a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a>            </span>
 </dt>
 <dd>The lower extreme of this `Range`.</dd>
+
+            <dt class="phpdocumentor-table-of-contents__entry -property -public">
+    <a class="" href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_start_excluded">$start_excluded</a>
+    <span>
+                        &nbsp;: <a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a>            </span>
+</dt>
+<dd>The lower extreme excluded, meaning the returning value is less than
+`$start`.</dd>
 
     </dl>
 
@@ -210,7 +226,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">19</span>
+    <span class="phpdocumentor-element-found-in__line">20</span>
 
     </aside>
 
@@ -236,6 +252,61 @@
             phpdocumentor-element
             -property
             -public
+                                                -read-only            -virtual        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_end_excluded">
+        $end_excluded
+        <a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_end_excluded" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                        <small class="phpdocumentor-element__modifier">read-only</small>            <small class="phpdocumentor-element__modifier">virtual</small>        </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">38</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">The higher extreme excluded, meaning the returning value is greater than
+`$end`.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__type"><a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a></span>
+    <span class="phpdocumentor-signature__name">$end_excluded</span>
+    </code>
+
+    
+    
+    
+
+        
+            <h5>Hooks</h5>
+            <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                <span class="phpdocumentor-signature__type"><a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a></span>
+        <span class="phpdocumentor-signature__name">get</span>
+</code>
+
+
+
+
+
+
+    
+    
+
+
+    
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -public
                                                                     "
 >
     <h4 class="phpdocumentor-element__name" id="property_start">
@@ -248,7 +319,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">14</span>
+    <span class="phpdocumentor-element-found-in__line">15</span>
 
     </aside>
 
@@ -267,6 +338,61 @@
 
         
         
+
+</article>
+                    <article
+        class="
+            phpdocumentor-element
+            -property
+            -public
+                                                -read-only            -virtual        "
+>
+    <h4 class="phpdocumentor-element__name" id="property_start_excluded">
+        $start_excluded
+        <a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_start_excluded" class="headerlink"><i class="fas fa-link"></i></a>
+
+        <span class="phpdocumentor-element__modifiers">
+                        <small class="phpdocumentor-element__modifier">read-only</small>            <small class="phpdocumentor-element__modifier">virtual</small>        </span>
+    </h4>
+    <aside class="phpdocumentor-element-found-in">
+    <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
+    :
+    <span class="phpdocumentor-element-found-in__line">26</span>
+
+    </aside>
+
+        <p class="phpdocumentor-summary">The lower extreme excluded, meaning the returning value is less than
+`$start`.</p>
+
+    
+    <code class="phpdocumentor-code phpdocumentor-signature ">
+        <span class="phpdocumentor-signature__visibility">public</span>
+            <span class="phpdocumentor-signature__type"><a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a></span>
+    <span class="phpdocumentor-signature__name">$start_excluded</span>
+    </code>
+
+    
+    
+    
+
+        
+            <h5>Hooks</h5>
+            <code class="phpdocumentor-code phpdocumentor-signature ">
+    <span class="phpdocumentor-signature__visibility">public</span>
+                <span class="phpdocumentor-signature__type"><a href="classes/MarcoConsiglio-BCMathExtended-Number.html"><abbr title="\MarcoConsiglio\BCMathExtended\Number">Number</abbr></a></span>
+        <span class="phpdocumentor-signature__name">get</span>
+</code>
+
+
+
+
+
+
+    
+    
+
+
+    
 
 </article>
             </section>
@@ -291,7 +417,7 @@
     <aside class="phpdocumentor-element-found-in">
     <abbr class="phpdocumentor-element-found-in__file" title="src/Range.php"><a href="files/src-range.html"><abbr title="src/Range.php">Range.php</abbr></a></abbr>
     :
-    <span class="phpdocumentor-element-found-in__line">27</span>
+    <span class="phpdocumentor-element-found-in__line">52</span>
 
     </aside>
 
@@ -445,7 +571,9 @@
                 <li>
                     <ul class="phpdocumentor-list -clean">
                                                     <li class=""><a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_end">$end</a></li>
+                                                    <li class=""><a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_end_excluded">$end_excluded</a></li>
                                                     <li class=""><a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_start">$start</a></li>
+                                                    <li class=""><a href="classes/MarcoConsiglio-BCMathExtended-Range.html#property_start_excluded">$start_excluded</a></li>
                                             </ul>
                 </li>
             

--- a/docs/html/js/searchIndex.js
+++ b/docs/html/js/searchIndex.js
@@ -441,6 +441,16 @@ Search.appendIndex(
             "summary": "The\u0020higher\u0020extreme\u0020of\u0020this\u0020\u0060Range\u0060.",
             "url": "classes/MarcoConsiglio-BCMathExtended-Range.html#property_end"
         },                {
+            "fqsen": "\\MarcoConsiglio\\BCMathExtended\\Range\u003A\u003A\u0024start_excluded",
+            "name": "start_excluded",
+            "summary": "The\u0020lower\u0020extreme\u0020excluded,\u0020meaning\u0020the\u0020returning\u0020value\u0020is\u0020less\u0020than\n\u0060\u0024start\u0060.",
+            "url": "classes/MarcoConsiglio-BCMathExtended-Range.html#property_start_excluded"
+        },                {
+            "fqsen": "\\MarcoConsiglio\\BCMathExtended\\Range\u003A\u003A\u0024end_excluded",
+            "name": "end_excluded",
+            "summary": "The\u0020higher\u0020extreme\u0020excluded,\u0020meaning\u0020the\u0020returning\u0020value\u0020is\u0020greater\u0020than\n\u0060\u0024end\u0060.",
+            "url": "classes/MarcoConsiglio-BCMathExtended-Range.html#property_end_excluded"
+        },                {
             "fqsen": "\\",
             "name": "\\",
             "summary": "",

--- a/phpdoc.xml
+++ b/phpdoc.xml
@@ -9,7 +9,7 @@
     <paths>
         <output>docs/html</output>
     </paths>
-    <version number="2.5.0">
+    <version number="2.7.0">
         <api>
             <source dsn=".">
                 <path>src</path>

--- a/src/Range.php
+++ b/src/Range.php
@@ -2,6 +2,7 @@
 namespace MarcoConsiglio\BCMathExtended;
 
 use BcMath\Number as BcMathNumber;
+use MarcoConsiglio\FakerPhpNumberHelpers\NextFloat;
 
 /**
  * The numeric range.
@@ -17,6 +18,30 @@ class Range
      * The higher extreme of this `Range`.
      */
     public protected(set) Number $end;
+
+    /**
+     * The lower extreme excluded, meaning the returning value is less than 
+     * `$start`.
+     */
+    public Number $start_excluded {
+        get {
+            return new Number(
+                NextFloat::before($this->start->toFloat())
+            );
+        }
+    }
+
+    /**
+     * The higher extreme excluded, meaning the returning value is greater than
+     * `$end`.
+     */
+    public Number $end_excluded {
+        get {
+            return new Number(
+                NextFloat::after($this->end->toFloat())
+            );
+        }
+    }
 
     /**
      * Construct a numeric `Range`.

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -34,10 +34,8 @@ class BaseTestCase extends TestCase
      * Instantiate a BcMathExtended\Number class from an int, string or
      * BcMath\Number instance, is is not already a BcMathExtended\Number
      * instance.
-     * 
-     * @param int|string|BcMathNumber|Number $number
      */
-    protected function instantiateNumber(mixed $number): Number
+    protected function instantiateNumber(int|float|string|BcMathNumber|Number $number): Number
     {
         return $number instanceof Number ? $number : new Number($number);
     }

--- a/tests/Feature/NumberTest.php
+++ b/tests/Feature/NumberTest.php
@@ -361,11 +361,10 @@ class NumberTest extends TestCaseWithDataProviders
          * a lower precision.
          */
         $number = $this->instantiateNumber(
-            $original_number = round(
-                $this->randomFloat(max: $this::MAX)),
-                3,
-                RoundingMode::HalfTowardsZero
-        );
+            new Number($original_number = round(
+                $this->randomFloat(max: $this::MAX),
+                3, RoundingMode::HalfTowardsZero
+        )));
 
         // Act
         $absolute = $number->abs();

--- a/tests/Feature/RangeTest.php
+++ b/tests/Feature/RangeTest.php
@@ -3,9 +3,11 @@ namespace MarcoConsiglio\BCMathExtended\Tests\Feature;
 
 use MarcoConsiglio\BCMathExtended\Builders\FromFloat;
 use MarcoConsiglio\BCMathExtended\Builders\FromInt;
+use MarcoConsiglio\BCMathExtended\Builders\FromParent;
 use MarcoConsiglio\BCMathExtended\Number;
 use MarcoConsiglio\BCMathExtended\Range;
 use MarcoConsiglio\BCMathExtended\Tests\BaseTestCase;
+use MarcoConsiglio\FakerPhpNumberHelpers\NextFloat;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 
@@ -13,6 +15,7 @@ use PHPUnit\Framework\Attributes\UsesClass;
 #[UsesClass(FromFloat::class)]
 #[UsesClass(Number::class)]
 #[UsesClass(FromInt::class)]
+#[UsesClass(FromParent::class)]
 class RangeTest extends BaseTestCase
 {
     public function test_range(): void
@@ -76,5 +79,22 @@ class RangeTest extends BaseTestCase
         // Assert
         $this->assertSame(new Number($start)->value, $range->start->value);
         $this->assertSame(new Number($end)->value, $range->end->value);
+    }
+
+    public function test_range_extremes_excluded(): void
+    {
+        // Arrange
+        $start = -10;
+        $end = -$start;
+        $range = new Range($start, $end); 
+        $expected_start = NextFloat::before($start);
+        $expected_end = NextFloat::after($end);
+
+        // Act
+        $range = new Range($start, $end);
+
+        // Assert
+        $this->assertEquals($expected_start, $range->start_excluded->toFloat());
+        $this->assertEquals($expected_end, $range->end_excluded->toFloat());
     }
 }

--- a/tests/TestCaseWithDataProviders.php
+++ b/tests/TestCaseWithDataProviders.php
@@ -350,6 +350,7 @@ class TestCaseWithDataProviders extends BaseTestCase
     {
         if ($min_or_max != "min" && $min_or_max != "max") $min_or_max = "max";
         $count = self::positiveRandomInteger(2, 5);
+        $vars = [];
         for ($i = 0; $i <= $count - 1; $i++) {
             $vars[$i] = self::randomInteger();
         }
@@ -546,6 +547,7 @@ class TestCaseWithDataProviders extends BaseTestCase
     {
         if ($min_or_max != "min" && $min_or_max != "max") $min_or_max = "max";
         $count = self::positiveRandomInteger(2, 5);
+        $vars = [];
         for ($i = 0; $i <= $count - 1; $i ++) {
             $vars[$i] = self::randomFloat(max: $max_random);
         }
@@ -578,12 +580,12 @@ class TestCaseWithDataProviders extends BaseTestCase
     {
         $a = self::randomFloat(min: -$max, max: $max, precision: 3);
         $b = self::randomFloat(min: -$max, max: $max, precision: 3);
-        $A = new BcMathNumber(self::string($a));
-        $B = new BcMathNumber(self::string($b));
+        $A = new BcMathNumber(Number::string($a));
+        $B = new BcMathNumber(Number::string($b));
         return [
             $a,
             $b,
-            self::string($A->add($B)->value)
+            Number::string($A->add($B)->value)
         ];
     }
 
@@ -739,6 +741,7 @@ class TestCaseWithDataProviders extends BaseTestCase
     {
         if ($min_or_max != "min" && $min_or_max != "max") $min_or_max = "max";
         $count = self::positiveRandomInteger(2, 5);
+        $vars = [];
         for ($i = 0; $i <= $count - 1; $i ++) {
             $vars[$i] = self::randomFloat(max: $max_random, precision: 3);
         }


### PR DESCRIPTION
# Changelog
## v2.7.0 2026-05-13
### Added
- `Range::`{`$start_excluded`,`$end_excluded`} to obtain the range extremes excluding one or both of them.